### PR TITLE
update libvirt provider

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.8.1"
+      version = "0.8.3"
     }
   }
 }


### PR DESCRIPTION
to fix this error on ubuntu noble with latest terraform release:

Error: Incompatible provider version
Provider registry.terraform.io/dmacvicar/libvirt v0.8.1 does not have a package available for your current platform, linux_amd64. Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider may have different platforms supported.